### PR TITLE
fixup! python: cachelib package added

### DIFF
--- a/lang/python/python-cachelib/Makefile
+++ b/lang/python/python-cachelib/Makefile
@@ -4,21 +4,19 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=cachelib
+PKG_NAME:=python-cachelib
 PKG_VERSION:=0.1
 PKG_RELEASE:=1
 
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+PKG_SOURCE:=cachelib-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://files.pythonhosted.org/packages/source/c/cachelib
 PKG_HASH:=8b889b509d372095357b8705966e1282d40835c4126d7c2b07fd414514d8ae8d
 
-PKG_MAINTAINER:=Daniel Golle <daniel@makrotopia.org>
+PKG_MAINTAINER:=Stepan Henek <stepan.henek@nic.cz>
 PKG_LICENSE:=BSD-3-Clause
 PKG_LICENSE_FILES:=LICENSE
 
-PKG_BUILD_DEPENDS:=python3
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(BUILD_VARIANT)-$(PKG_NAME)-$(PKG_VERSION)
-PKG_UNPACK=$(HOST_TAR) -C $(PKG_BUILD_DIR) --strip-components=1 -xzf $(DL_DIR)/$(PKG_SOURCE)
+PKG_BUILD_DIR:=$(BUILD_DIR)/cachelib-$(PKG_VERSION)
 
 include $(INCLUDE_DIR)/package.mk
 include ../python3-package.mk
@@ -27,16 +25,15 @@ define Package/python3-cachelib
   SECTION:=lang
   CATEGORY:=Languages
   SUBMENU:=Python
+  TITLE:=cachelib
   URL:=https://github.com/pallets/cachelib
-  TITLE:=python3-cachelib
   DEPENDS:=+python3-light
   VARIANT:=python3
 endef
 
 define Package/python3-cachelib/description
-cachelib
-
-A collection of cache libraries in the same API interface. Extracted from werkzeug.
+  A collection of cache libraries in the same API interface.
+  Extracted from werkzeug.
 endef
 
 $(eval $(call Py3Package,python3-cachelib))


### PR DESCRIPTION
Here are a few changes for the submitted pull request.

Ideally, PKG_NAME should be the same as the folder name.
PKG_UNPACK is not necessary neither PKG_BUILD_DEPENDS.

About maintainership, if you don't want to be maintainer, it's fine, you can put me there.

Compile tested on Turris MOX, OpenWrt 19.07. Contents verified. 
Run testing will be done later, probably on Sunday, hopefully, sooner.